### PR TITLE
Bug fix, add before and after in all comp page

### DIFF
--- a/src/screenshotbot/compare.lisp
+++ b/src/screenshotbot/compare.lisp
@@ -380,8 +380,8 @@
                 collect
                 <div class= "image-comparison-wrapper" >
                 <h3>,(screenshot-name before)</h3>
-                <change-image-row-triple before-image=(image-public-url (screenshot-image before) :size :half-page)
-                                         after-image=(image-public-url (screenshot-image after) :size :half-page)
+                <change-image-row-triple before-image=(image-public-url (screenshot-image before) :size :full-page)
+                                         after-image=(image-public-url (screenshot-image after) :size :full-page)
                                          comp-image=comparison-image
                                          />
                 </div>))

--- a/src/screenshotbot/compare.lisp
+++ b/src/screenshotbot/compare.lisp
@@ -193,6 +193,16 @@
     <img class= "screenshot-image change-image change-image-right" src= after-image />
   </div>)
 
+(deftag change-image-row-triple (&key before-image
+                          after-image
+                          comp-image)
+  <div class="change-image-row">
+    <img class= "screenshot-image change-image change-image-left" src= before-image />
+    <img class= "screenshot-image change-image change-image-right" src= after-image />
+    <:img data-src= comp-image
+      class= "bg-primary image-comparison-modal-image" alt= "Image Difference" />
+  </div>) 
+
 (defclass image-comparison-job ()
   ((donep :initform nil
           :accessor donep)
@@ -310,19 +320,10 @@
                 collect
                 <div class= "image-comparison-wrapper" >
                 <h3>,(screenshot-name before)</h3>
-                <progress-img
-                src= comparison-image
-                class= "mb-3"
-                zoom-to= (util:copying (before after)
-                           (nibble ()
-                             (random-zoom-to before after)))
-                />
-
-                <div>
-                <zoom-to-change-button />
-                </div>
-                <hr />
-
+                <change-image-row-triple before-image=(image-public-url (screenshot-image before) :size :half-page)
+                                         after-image=(image-public-url (screenshot-image after) :size :half-page)
+                                         comp-image=comparison-image
+                                         />
                 </div>))
         5)
   </app-template>)

--- a/src/screenshotbot/dashboard/image.lisp
+++ b/src/screenshotbot/dashboard/image.lisp
@@ -31,6 +31,7 @@
 (defun handle-resized-image (image size)
   (let* ((size (cond
                  ((string-equal "small" size) "300x300")
+                 ((string-equal "half-page" size) "600x600")
                  ((string-equal "full-page" size) "2000x2000")
                 (t (error "invalid image size: ~a" size))))
          (output-file

--- a/src/screenshotbot/magick.lisp
+++ b/src/screenshotbot/magick.lisp
@@ -28,7 +28,7 @@
   (restart-case
       (call-with-semaphore
        *semaphore*
-       (lambda ()q
+       (lambda ()
         (let ((command (loop for str in command
                              if (pathnamep str)
                                collect (namestring str)


### PR DESCRIPTION
This PR is going to:

1. Fix a bug in **src/screenshotbot/magick.lisp** (An unexpected `q` there)
2. Add `"half-page"` config in **src/screenshotbot/dashboard/image.lisp**
3. Add **before** and **after** in All Pixel Comparisons page, which would looks like

<img width="800" alt="triple-row" src="https://user-images.githubusercontent.com/19320783/152565060-1ee215bb-d879-474c-ab50-d3f6a76aaaaf.png">

I have tested it:)

