### PR TITLE
Proposal for hiding similar images

### DIFF
--- a/src/screenshotbot/compare.lisp
+++ b/src/screenshotbot/compare.lisp
@@ -327,7 +327,7 @@
       (draw-masks-in-place p (screenshot-masks after-screenshot) :color "rgba(255, 255, 0, 0.8)")
       p)))
 
-(defun is-image-similiar (before-screenshot
+(defun is-image-similar (before-screenshot
                             after-screenshot)
   (with-local-image (before before-screenshot)
     (with-local-image (after after-screenshot)
@@ -403,7 +403,7 @@
                                          (nibble ()
                                            (prepare-image-comparison image-comparison-job :size :full-page)))
 
-                for image-campare-ret = (is-image-similiar before after)
+                for image-campare-ret = (is-image-similar before after)
                 collect
                 <div class= "image-comparison-wrapper" >
                 <h3>,(if (= image-campare-ret 1) (screenshot-name before) (concatenate 'string (screenshot-name before) " are same"))</h3>

--- a/src/screenshotbot/compare.lisp
+++ b/src/screenshotbot/compare.lisp
@@ -406,7 +406,7 @@
                 for image-campare-ret = (is-image-similiar before after)
                 collect
                 <div class= "image-comparison-wrapper" >
-                <h3>,(screenshot-name before)</h3>
+                <h3>,(if (= image-campare-ret 1) (screenshot-name before) (concatenate 'string (screenshot-name before) " are same"))</h3>
                 ,(when (= image-campare-ret 1)
                 <change-image-row-triple before-image=(image-public-url (screenshot-image before) :size :full-page)
                                          after-image=(image-public-url (screenshot-image after) :size :full-page)

--- a/src/screenshotbot/compare.lisp
+++ b/src/screenshotbot/compare.lisp
@@ -396,22 +396,22 @@
           (loop for change in changes
                 for before = (before change)
                 for after = (after change)
-                for image-comparison-job = (make-instance 'image-comparison-job
-                                                           :before-image before
-                                                           :after-image after)
-                for comparison-image = (util:copying (image-comparison-job)
-                                         (nibble ()
-                                           (prepare-image-comparison image-comparison-job :size :full-page)))
 
                 for image-campare-ret = (is-image-similar before after)
                 collect
                 <div class= "image-comparison-wrapper" >
-                <h3>,(if (= image-campare-ret 1) (screenshot-name before) (concatenate 'string (screenshot-name before) " are same"))</h3>
+                <h3>,(if (= image-campare-ret 1) (screenshot-name before) (concatenate 'string (screenshot-name before) " are the same"))</h3>
                 ,(when (= image-campare-ret 1)
-                <change-image-row-triple before-image=(image-public-url (screenshot-image before) :size :full-page)
+                  (let* ((image-comparison-job (make-instance 'image-comparison-job
+                                                           :before-image before
+                                                           :after-image after))
+                        (comparison-image (util:copying (image-comparison-job)
+                                         (nibble ()
+                                           (prepare-image-comparison image-comparison-job :size :full-page)))))
+                        <change-image-row-triple before-image=(image-public-url (screenshot-image before) :size :full-page)
                                          after-image=(image-public-url (screenshot-image after) :size :full-page)
                                          comp-image=comparison-image
-                                         />)
+                                         />))
                 </div>))
         5)
   </app-template>)


### PR DESCRIPTION
This PR is a early step proposal for hiding similar images in **All Pixel Comparison** page, which will turn the following page
<img width="600" alt="show_img" src="https://user-images.githubusercontent.com/19320783/152635159-97d0417e-d24d-475f-9c2a-2c2ed3486984.png">

Into
<img width="600" alt="hide_img" src="https://user-images.githubusercontent.com/19320783/152635169-79aa8227-b833-45ae-8f28-b29364fea0e7.png">

As the examples show above, there're slightly difference between the **music_1** images, mean while the images of **music_2** are basically the same. In this case, we just hide **music_2** in an ugly way:

1. `is-image-similiar` shares most of its logic from `do-image-comparison`, that means the comparing operations would have to double. We may easily integrate `is-image-similiar` into `do-image-comparison` later. At this moment, to avoid regression and just for this prototype, I would just left it in this way.
2. I'm using `,(when (= image-campare-ret 1)` to guard, it's so ad-hoc. we may use [How TO - Toggle Hide and Show](https://www.w3schools.com/howto/howto_js_toggle_hide_show.asp) to toggle the same images and provide buttons for each `div` to show it again.

Any idea to reuse the current logic in the code base to make it works?

