### PR TITLE
Fix cli build script

### DIFF
--- a/scripts/build-cli.lisp
+++ b/scripts/build-cli.lisp
@@ -13,15 +13,15 @@
 #+sbcl
 (sb-ext:save-lisp-and-die *output*
                           :purify t
-                          :toplevel 'screenshotbot-sdk:main
+                          :toplevel 'screenshotbot/sdk/main:main
                           :executable t)
 
 #+ccl
 (ccl:save-application *output*
-                      :toplevel-function 'screenshotbot-sdk:main)
+                      :toplevel-function 'screenshotbot/sdk/main:main)
 
 #+lispworks
-(deliver 'screenshotbot-sdk:main *output* 5
+(deliver 'screenshotbot/sdk/main:main *output* 5
           :keep-function-name t
           :keep-pretty-printer t
           :keep-lisp-reader t


### PR DESCRIPTION
In 
https://github.com/screenshotbot/screenshotbot-oss/commit/e9f60381f0632699a13e117f3b2d7caa598d369a#diff-9d66d67fdaf638631ee45644b81bbc44983c4060b7a77753c74c6bfaf62e2f79

the main func was split outside of the sdk.lisp file into it's own main.lisp, which broke this build script.