### PR TITLE
fix: typo in November update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SBCL, Clozure CL (CCL) and LispWorks, but the core features should work on
 any compliant Common Lisp.
 
 *Update Nov 2022: We're switching our primary docker images from CCL
-to SBCL. SBCL is more performan and more stable than CCL. See this
+to SBCL. SBCL is more performant and more stable than CCL. See this
 [migration
 guide](https://github.com/screenshotbot/screenshotbot-oss/wiki/Porting-from-CCL-to-SBCL)
 if you have an existing store. Let us know if you have any issues with


### PR DESCRIPTION
This PR fixes the little typo I found in the readme. 